### PR TITLE
Prefix support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,7 @@ prefix: Fe
 currency:
   single: Fe
   multiple: Fe
+  isprefix: false
 
 type: sqlite
 

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ prefix: Fe
 currency:
   single: Fe
   multiple: Fe
-  isprefix: false
+  prefix: ""
 
 type: sqlite
 

--- a/src/org/melonbrew/fe/API.java
+++ b/src/org/melonbrew/fe/API.java
@@ -29,6 +29,10 @@ public class API {
 		return plugin.getConfig().getDouble("maxholdings");
 	}
 
+        public String getCurrencyPrefix(){
+		return plugin.getConfig().getString("currency.prefix");
+	}
+        
 	public String getCurrencySingle(){
 		return plugin.getConfig().getString("currency.single");
 	}
@@ -61,20 +65,13 @@ public class API {
 		amount = getMoneyRounded(amount);
 		
                 String prefix = "";
-		String suffix = " ";
+		String suffix = "";
 		
-                if (plugin.getConfig().getBoolean("currency.isprefix")){
-                    	if (amount == 1.0){
-                            prefix += getCurrencySingle();
-                        }else {
-                            prefix += getCurrencyMultiple();
-                        }
-                }else{
-                    	if (amount == 1.0){
-                            suffix += getCurrencySingle();
-                        }else {
-                            suffix += getCurrencyMultiple();
-                        }
+                prefix += getCurrencyPrefix();
+                if (amount == 1.0){
+                        suffix = " " + getCurrencySingle();
+                }else {
+                        suffix = " " + getCurrencyMultiple();
                 }
 		
 		return Phrase.SECONDARY_COLOR.parse() + prefix + Phrase.PRIMARY_COLOR.parse() + moneyFormat.format(amount) + Phrase.SECONDARY_COLOR.parse() + suffix;

--- a/src/org/melonbrew/fe/API.java
+++ b/src/org/melonbrew/fe/API.java
@@ -28,7 +28,7 @@ public class API {
 	public double getMaxHoldings(){
 		return plugin.getConfig().getDouble("maxholdings");
 	}
-	
+
 	public String getCurrencySingle(){
 		return plugin.getConfig().getString("currency.single");
 	}
@@ -60,15 +60,24 @@ public class API {
 	public String format(double amount){
 		amount = getMoneyRounded(amount);
 		
+                String prefix = "";
 		String suffix = " ";
 		
-		if (amount == 1.0){
-			suffix += getCurrencySingle();
-		}else {
-			suffix += getCurrencyMultiple();
-		}
+                if (plugin.getConfig().getBoolean("currency.isprefix")){
+                    	if (amount == 1.0){
+                            prefix += getCurrencySingle();
+                        }else {
+                            prefix += getCurrencyMultiple();
+                        }
+                }else{
+                    	if (amount == 1.0){
+                            suffix += getCurrencySingle();
+                        }else {
+                            suffix += getCurrencyMultiple();
+                        }
+                }
 		
-		return Phrase.PRIMARY_COLOR.parse() + moneyFormat.format(amount) + Phrase.SECONDARY_COLOR.parse() + suffix;
+		return Phrase.SECONDARY_COLOR.parse() + prefix + Phrase.PRIMARY_COLOR.parse() + moneyFormat.format(amount) + Phrase.SECONDARY_COLOR.parse() + suffix;
 	}
 	
 	public double getMoneyRounded(double amount){


### PR DESCRIPTION
First of all, [we](http://dragon-weed.net) love this plugin.

However, it lacks prefix support, which we need. Our currency is $, and it is weird to have 256 $ amounts (given that you do that in Europe, but still). We'd like to deal in $256 instead.
