### PR TITLE
Fix "Bad format for number" error

### DIFF
--- a/src/org/melonbrew/fe/database/databases/SQLDB.java
+++ b/src/org/melonbrew/fe/database/databases/SQLDB.java
@@ -181,7 +181,7 @@ public abstract class SQLDB extends Database {
 			Double money = null;
 
 			while (set.next()){
-				money = set.getDouble(accountsColumnUser);
+				money = set.getDouble(accountsColumnMoney);
 			}
 
 			set.close();


### PR DESCRIPTION
Fixing this issue

money = set.getDouble(accountsColumnUser)

`````` java
10:35:10 [WARN] java.sql.SQLException: Bad format for number 'xx' in column 1.
10:35:10 [WARN]         at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:1073)
10:35:10 [WARN]         at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:987)
10:35:10 [WARN]         at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:982)
10:35:10 [WARN]         at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:927)
10:35:10 [WARN]         at com.mysql.jdbc.ResultSetImpl.getDoubleInternal(ResultSetImpl.java:2522)
10:35:10 [WARN]         at com.mysql.jdbc.ResultSetImpl.getDoubleInternal(ResultSetImpl.java:2461)
10:35:10 [WARN]         at com.mysql.jdbc.ResultSetImpl.getDouble(ResultSetImpl.java:2422)
10:35:10 [WARN]         at com.mysql.jdbc.ResultSetImpl.getDouble(ResultSetImpl.java:2440)
10:35:10 [WARN]         at org.melonbrew.fe.database.databases.SQLDB.loadAccountMoney(SQLDB.java:184)
10:35:10 [WARN]         at org.melonbrew.fe.database.Account.getMoney(Account.java:26)
10:35:10 [WARN]         at org.melonbrew.fe.API.format(API.java:143)
10:35:10 [WARN]         at org.melonbrew.fe.command.commands.TopCommand.onCommand(TopCommand.java:38)
10:35:10 [WARN]         at org.melonbrew.fe.FeCommand.onCommand(FeCommand.java:123)
10:35:10 [WARN]         at org.bukkit.command.PluginCommand.execute(PluginCommand.java:44)
10:35:10 [WARN]         at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:199)
10:35:10 [WARN]         at org.bukkit.craftbukkit.v1_7_R1.CraftServer.dispatchCommand(CraftServer.java:547)
10:35:10 [WARN]         at org.bukkit.craftbukkit.v1_7_R1.CraftServer.dispatchServerCommand(CraftServer.java:534)
10:35:10 [WARN]         at net.minecraft.server.v1_7_R1.DedicatedServer.aw(DedicatedServer.java:309)
10:35:10 [WARN]         at net.minecraft.server.v1_7_R1.DedicatedServer.u(DedicatedServer.java:274)
10:35:10 [WARN]         at net.minecraft.server.v1_7_R1.MinecraftServer.t(MinecraftServer.java:560)
10:35:10 [WARN]         at net.minecraft.server.v1_7_R1.MinecraftServer.run(MinecraftServer.java:467)
10:35:10 [WARN]         at net.minecraft.server.v1_7_R1.ThreadServerApplication.run(SourceFile:617)```
``````
